### PR TITLE
docs: MSc HCNN × Solar-PV topics + program roadmap

### DIFF
--- a/docs/msc_topics_solar_pv.md
+++ b/docs/msc_topics_solar_pv.md
@@ -1,0 +1,213 @@
+# MSc Research Topics — HCNN × Solar Photovoltaics
+
+Candidate Master's thesis topics combining the **Historically Consistent Neural
+Network (HCNN)** framework with Solar PV engineering. Each topic is deliberately
+framed so the PV system is treated as a **partially-observed nonlinear dynamical
+system**, which is what makes HCNN *required* rather than optional.
+
+## The two levers that make these HCNN theses (not "ML on solar")
+
+1. **Unmeasured drivers become HCNN hidden states.** Soiling load, cell
+   temperature, single-diode parameters, degradation state, and shading
+   configuration are physically real but rarely instrumented. HCNN infers them as
+   latent state from the observable I/V/P/weather stream.
+2. **The teacher-forcing innovation is a physical residual.** The correction
+   `δ_t = measured − expected` is a Kalman/observer innovation. Because the HCNN
+   explains weather-driven variation in its hidden states, `δ` isolates *genuine*
+   deviations (faults, drift), and the **autonomous rollout** is a
+   trajectory-preserving forecast rather than a smooth extrapolation.
+
+Variant guide: **Vanilla** (baseline), **PTF** (noisy field telemetry), **LForm**
+(slow / long-memory dynamics such as degradation and thermal inertia), **LSpa**
+(high-dimensional arrays / fleets); **Ensembles** for calibrated uncertainty.
+
+---
+
+## Suggestion 1 — ML-Based MPPT for PV Systems
+
+### Topic 1.1
+🔬 **Formal Thesis Title:** *A Historically Consistent Neural Observer for Predictive Maximum Power Point Tracking under Stochastically Fluctuating Irradiance*
+
+❓ **Core Scientific Problem:** The MPP is a moving target on the nonlinear P–V manifold, driven by turbulent (effectively chaotic) cloud dynamics. Perturb-and-Observe / Incremental-Conductance oscillate and lose energy on fast ramps; LSTM/ANN predictors are accurate one step ahead but drift and violate I–V physics over the multi-step control horizon.
+
+📐 **How HCNN Philosophy Fits:** The historically-consistent variable is the **(V_mp, I_mp) locus trajectory**; latent irradiance/thermal dynamics are hidden states. The innovation feedback corrects unmodeled cloud transients; the rollout forecasts the MPP set-point ahead of time → predictive, not reactive, MPPT.
+
+🛠️ **Methodology Summary:** Observed state = {V, I, P, module temp, POA irradiance if available}; hidden vars for latent cloud/thermal dynamics. Roll out a short-horizon MPP forecast as the converter reference; single-diode I–V relation as a soft physics prior.
+
+📊 **Key Evaluation Metrics:** Tracking efficiency (%), harvested energy vs P&O/INC/PSO, transient recovery time, steady-state oscillation amplitude, valid-prediction-time under ramps.
+
+### Topic 1.2
+🔬 **Formal Thesis Title:** *Single-Diode-Constrained Historically Consistent Networks for Model-Based MPPT with Online Parameter Estimation*
+
+❓ **Core Scientific Problem:** Purely data-driven MPPT discards the known I–V physics and extrapolates poorly to unseen irradiance/temperature; the five single-diode parameters drift slowly with temperature and aging.
+
+📐 **How HCNN Philosophy Fits:** The dynamical prior is the **single-diode equation**; the slowly-drifting diode parameters are the hidden states (a deep Extended-Kalman-style parameter observer). **LForm** suits the slow drift.
+
+🛠️ **Methodology Summary:** Hidden state encodes diode parameters; observation predicts current from voltage via the diode equation; teacher-force on measured current; locate the MPP analytically from the estimated curve.
+
+📊 **Key Evaluation Metrics:** Parameter-ID accuracy vs offline curve-fitting, MPP tracking efficiency, noise robustness (PTF vs Vanilla), generalization to unseen G/T.
+
+---
+
+## Suggestion 2 — Fault Detection & Diagnosis
+
+### Topic 2.1
+🔬 **Formal Thesis Title:** *Innovation-Residual Fault Detection in PV Systems via Historically Consistent Neural Observers*
+
+❓ **Core Scientific Problem:** Faults are deviations from normal dynamics, but supervised classifiers need scarce labels and raise false alarms because they cannot separate weather-driven from fault-driven change.
+
+📐 **How HCNN Philosophy Fits:** The strongest fit in the set — the observer **innovation `δ_t` is the physically-grounded residual**. Weather variation is explained by the hidden states, so a residual shift isolates a genuine fault. Trains only on healthy data (unsupervised / open-set).
+
+🛠️ **Methodology Summary:** Train on healthy-plant series; monitor the innovation online with CUSUM/statistical change-detection; classify fault type by residual signature and (arrays) spatial pattern via LSpa.
+
+📊 **Key Evaluation Metrics:** Detection rate vs false-alarm rate under variable weather, time-to-detect incipient faults, AUC vs supervised CNN/SVM, unseen-fault-type detection (open-set).
+
+### Topic 2.2
+🔬 **Formal Thesis Title:** *Historically Consistent Prognostics of PV Degradation Trajectories for Remaining-Useful-Life Estimation*
+
+❓ **Core Scientific Problem:** Degradation (PID, LID, corrosion) is slow, nonlinear and path-dependent; regression gives points, not physically-plausible monotone trajectories, and multi-year extrapolation is unstable.
+
+📐 **How HCNN Philosophy Fits:** A latent **degradation state** evolving monotonically; the long-horizon rollout preserves the trajectory shape. **LForm** for long memory; ensembles for RUL intervals.
+
+🛠️ **Methodology Summary:** Hidden degradation states on multi-year performance + weather; monotonicity constraint; roll out years ahead; `predict_with_uncertainty` + conformal calibration for RUL bounds.
+
+📊 **Key Evaluation Metrics:** RUL error, long-horizon efficiency forecast error, trajectory plausibility, RUL-interval coverage/calibration, vs Kalman/particle-filter prognostics.
+
+### Topic 2.3
+🔬 **Formal Thesis Title:** *Large-Sparse HCNN for Spatially-Resolved Fault Localization in PV Arrays*
+
+❓ **Core Scientific Problem:** Localizing *which* module/string is faulty is a high-dimensional, spatially-coupled problem; thermography/image methods need dedicated hardware and labels.
+
+📐 **How HCNN Philosophy Fits:** **LSpa**'s sparsity mask encodes the physical electrical topology; localized residual spikes point to the faulty node; historical consistency separates spatially-correlated weather from local faults.
+
+🛠️ **Methodology Summary:** LSpa mask from the wiring graph; string-level measurements; map spatial innovation pattern to module/string localization.
+
+📊 **Key Evaluation Metrics:** Localization accuracy, sensor economy, vs thermographic-CNN pipelines under variable irradiance.
+
+---
+
+## Suggestion 3 — PV Efficiency Estimation under African Climate
+
+### Topic 3.1
+🔬 **Formal Thesis Title:** *Latent Soiling and Thermal Dynamics in Historically Consistent PV Efficiency Forecasting under Arid African Climates*
+
+❓ **Core Scientific Problem:** In arid/Sahelian conditions, **dust soiling** is the dominant *unmeasured* loss — accumulating nonlinearly and resetting hysteretically with rain/cleaning. Efficiency regressors have no state for it, so performance ratio drifts and cleaning is scheduled blindly.
+
+📐 **How HCNN Philosophy Fits:** Hidden state = soiling load (+ thermal dynamics); historically-consistent variable = the soiling accumulation/wash-off trajectory. The observer infers soiling from the power residual with no soiling sensor. **PTF** for noisy telemetry.
+
+🛠️ **Methodology Summary:** Inputs = POA irradiance, temperature, humidity, rainfall, AC power; hidden soiling+thermal states; teacher-force on power; validate soiling against known cleaning/rain events.
+
+📊 **Key Evaluation Metrics:** Efficiency/PR forecast error, inferred vs measured soiling ratio, economic value of an HCNN-optimized cleaning schedule, vs HSU/Kimber soiling models.
+
+### Topic 3.2
+🔬 **Formal Thesis Title:** *Climate-Adaptive Historically Consistent Networks for PV Efficiency Estimation across African Micro-Climates*
+
+❓ **Core Scientific Problem:** Models fit on one zone (coastal humid vs highland vs Sahel) fail elsewhere due to distribution shift, though device physics is shared; per-site ANNs retrain wastefully.
+
+📐 **How HCNN Philosophy Fits:** The shared dynamical prior transfers; climate-specific behavior is absorbed into hidden-state initialization and the observer gain, adapted per site with little data.
+
+🛠️ **Methodology Summary:** Pretrain a multi-site HCNN; few-shot adapt the hidden-state/gain to a new site; ensemble across sites for regional UQ.
+
+📊 **Key Evaluation Metrics:** Few-shot cross-climate forecast error, data-efficiency curves, vs site-specific ANN retraining, cross-zone uncertainty calibration.
+
+### Topic 3.3
+🔬 **Formal Thesis Title:** *Coupled Thermal–Electrical Historically Consistent Modeling of PV Efficiency under High-Temperature African Conditions*
+
+❓ **Core Scientific Problem:** Cell temperature governs efficiency and has real dynamics (thermal mass, wind, mounting) under strong diurnal heating; steady-state NOCT/Faiman models miss transients and cell temperature is partially observed.
+
+📐 **How HCNN Philosophy Fits:** A hidden **thermal state** coupled to electrical output; the energy-balance equation is the prior; the observer estimates cell temperature from the electrical residual.
+
+🛠️ **Methodology Summary:** Lumped thermal energy-balance prior; jointly forecast module temperature and efficiency; LForm (thermal inertia) vs Vanilla.
+
+📊 **Key Evaluation Metrics:** Cell-temperature RMSE vs back-of-module sensors, efficiency forecast error, vs Faiman/Sandia/Ross thermal models.
+
+---
+
+## Suggestion 4 — MPPT under Partial Shading
+
+### Topic 4.1
+🔬 **Formal Thesis Title:** *Historically Consistent Global-MPP Tracking on Multi-Peak P–V Manifolds under Dynamic Partial Shading*
+
+❓ **Core Scientific Problem:** Partial shading makes the P–V curve multi-modal; conventional MPPT traps in local peaks, and the global MPP jumps discontinuously (bifurcation-like) as shadows move — a regime-switching behavior smooth LSTMs cannot represent.
+
+📐 **How HCNN Philosophy Fits:** Model the manifold as a dynamical system with regime switches; hidden state encodes the bypass-diode activation configuration; the innovation detects a regime change (new peak) before the tracker stalls.
+
+🛠️ **Methodology Summary:** State includes the discrete bypass-diode regime + latent shading dynamics; forecast GMPP location and feed the converter; train/validate on moving-shadow scenarios. A selective/input-dependent transition (Mamba-style) is a natural upgrade.
+
+📊 **Key Evaluation Metrics:** GMPP tracking-success rate, local-MPP trapping rate, energy vs PSO/GWO global search, convergence speed under moving shadows.
+
+### Topic 4.2
+🔬 **Formal Thesis Title:** *Large-Sparse HCNN for Spatiotemporal Forecasting of Partial-Shading Propagation across PV Arrays*
+
+❓ **Core Scientific Problem:** Shadows propagate spatially across an array; predicting which modules shade next enables proactive reconfiguration — a high-dimensional coupled spatiotemporal problem point-wise MPPT ignores.
+
+📐 **How HCNN Philosophy Fits:** **LSpa** with a spatial-adjacency mask forecasts the shading front as a historically-consistent spatial trajectory.
+
+🛠️ **Methodology Summary:** LSpa mask = spatial neighborhood/topology; module-level irradiance/power; forecast the shading map to drive dynamic reconfiguration / distributed MPPT.
+
+📊 **Key Evaluation Metrics:** Shading-map forecast accuracy, energy gain from proactive vs static reconfiguration, valid prediction time of the shading front.
+
+### Topic 4.3
+🔬 **Formal Thesis Title:** *Uncertainty-Aware Historically Consistent GMPP Forecasting under Intermittent Shading using HCNN Ensembles*
+
+❓ **Core Scientific Problem:** Fast intermittent shading makes the near-future GMPP genuinely uncertain; deterministic MPPT over/under-commits and communicates no risk.
+
+📐 **How HCNN Philosophy Fits:** The HCNN ensemble (`predict_with_uncertainty`, `model_agreement`) yields a predictive distribution over the GMPP for risk-aware set-point control.
+
+🛠️ **Methodology Summary:** Deep-ensemble HCNN + conformal intervals; a risk-aware control rule weighting the set-point by forecast confidence.
+
+📊 **Key Evaluation Metrics:** CRPS and interval coverage of the GMPP forecast, harvested energy vs deterministic MPPT, robustness across intermittency levels.
+
+---
+
+## ⭐ Bonus — Cross-Disciplinary: PV → Microgrid / Smart-Grid Scaling
+
+### Bonus Topic A
+🔬 **Formal Thesis Title:** *Hierarchical Historically Consistent Forecasting of Distributed PV Fleets for Microgrid Dispatch under Regional Climate Patterns*
+
+❓ **Core Scientific Problem:** Microgrid dispatch needs multi-horizon net-generation forecasts aggregated over many heterogeneous distributed plants correlated by regional weather (Harmattan dust, monsoon fronts); independent per-plant models miss the spatiotemporal correlation driving system-level ramps.
+
+📐 **How HCNN Philosophy Fits:** A hierarchical / LSpa HCNN where each plant is a sub-state coupled through a shared regional-climate hidden state; the aggregate trajectory preserves fleet-level ramp dynamics; ensemble UQ sizes reserves.
+
+🛠️ **Methodology Summary:** Graph/hierarchical HCNN over plants with a regional climate driver; forecast aggregate and per-node generation with calibrated uncertainty for dispatch.
+
+📊 **Key Evaluation Metrics:** Aggregate net-load forecast skill, ramp-event forecasting, reserve/dispatch cost savings, vs persistence / LSTM / graph-NN baselines.
+
+### Bonus Topic B
+🔬 **Formal Thesis Title:** *Regime-Switching Historically Consistent Co-Forecasting of PV Generation and Demand for Smart-Grid Stability under Seasonal African Climate Cycles*
+
+❓ **Core Scientific Problem:** Grid stability requires joint PV-and-demand forecasting that survives seasonal regime shifts (dry/wet, cool/hot) and the coupling between chaotic weather and human demand — a coupled non-stationary dynamical system single-target models handle poorly.
+
+📐 **How HCNN Philosophy Fits:** A multivariate HCNN with a regime-switching hidden variable (latent seasonal/climate index) drives a selective transition, co-evolving PV, load and weather across regimes for long-horizon stability planning.
+
+🛠️ **Methodology Summary:** Multivariate HCNN (PV, load, weather) with a latent regime state; long-horizon rollout; evaluate against grid-stability proxies (ramp coverage, reserve adequacy).
+
+📊 **Key Evaluation Metrics:** Joint PV–demand forecast skill, regime-transition handling, grid-stability KPIs, economic-dispatch improvement.
+
+---
+
+## Selection matrix (topic × variant × prior × baseline × data × metric)
+
+Use this to help a student pick a topic that matches their interest and available data. "Hidden-state prior" is the unobserved dynamical variable the HCNN must infer — the crux of each thesis.
+
+| ID | Short title | HCNN variant | Hidden-state prior (the crux) | Engineering baseline to beat | Representative data | Headline metric |
+|----|-------------|--------------|-------------------------------|------------------------------|---------------------|-----------------|
+| 1.1 | Predictive MPP observer | Vanilla / PTF | latent irradiance + thermal dynamics | P&O, INC, PSO-MPPT | Simulink PV + measured irradiance (NREL/African station) | tracking efficiency, energy vs P&O |
+| 1.2 | Diode-constrained MPPT | LForm | single-diode parameters (drift) | offline curve-fit + P&O | I–V sweeps + G/T (Sandia, PVLib synthetic) | param-ID accuracy, MPP efficiency |
+| 2.1 | Innovation-residual faults | Vanilla + LSpa | weather-explained normal dynamics | supervised CNN/SVM, threshold | GPVS-Faults, DKASC healthy+fault | detection vs false-alarm, latency |
+| 2.2 | Degradation prognostics (RUL) | LForm + Ensemble | latent degradation state (monotone) | Kalman/particle-filter prognostics | multi-year fleet data (NREL, DKASC) | RUL error, interval coverage |
+| 2.3 | Array fault localization | LSpa | electrical-topology coupling | thermography-CNN | string/module-level plant SCADA | localization accuracy, sensor economy |
+| 3.1 | Latent soiling forecasting | PTF + LForm | soiling load (hysteretic) | HSU/Kimber soiling models | arid-site power + weather + rain (NASA POWER) | PR forecast, cleaning-schedule value |
+| 3.2 | Climate-adaptive efficiency | Vanilla + Ensemble | site-specific latent init/gain | site-specific ANN retrain | multi-site African micro-climate data | few-shot transfer error |
+| 3.3 | Thermal–electrical coupling | LForm | module thermal state | Faiman/Sandia/Ross thermal | high-T site power + back-of-module T | cell-T RMSE, efficiency error |
+| 4.1 | GMPP on multi-peak manifold | Vanilla (selective A) | bypass-diode regime + shading dynamics | PSO/GWO global MPPT | Simulink multi-module moving-shadow | GMPP success, trapping rate |
+| 4.2 | Shading-front spatiotemporal | LSpa | spatial-adjacency coupling | static config MPPT | module-level array irradiance/power | shading-map accuracy, energy gain |
+| 4.3 | Uncertainty-aware GMPP | Ensemble | GMPP predictive distribution | deterministic MPPT | intermittent-shading field/sim data | CRPS, coverage, energy |
+| A | PV-fleet microgrid forecast | LSpa / hierarchical + Ensemble | regional-climate coupling state | persistence, LSTM, graph-NN | distributed PV fleet + weather (OPSD) | aggregate skill, ramp forecast |
+| B | PV–demand co-forecast | Multivariate + selective A | seasonal regime index | independent PV & load models | co-located PV + load + weather | joint skill, grid-stability KPI |
+
+### Cross-cutting evaluation standards (adopt group-wide)
+- Report multi-step forecasts in **valid-prediction-time / horizon** terms, not just aggregate MSE.
+- For any predictive/UQ topic, report **calibrated uncertainty (CRPS + interval coverage)** — the ensemble UQ (`predict_with_uncertainty`, `model_agreement`) is built for this.
+- Always compare against the **domain engineering baseline** in the table, not only an LSTM, so "HCNN outperforms" is defensible.
+- Lead theses: **2.1** (residual = the science) and **1.2 / 3.1** (physically-real but unmeasured hidden states) are the hardest to reframe as "basic ML" and the most distinctively HCNN.

--- a/docs/research_program_roadmap.md
+++ b/docs/research_program_roadmap.md
@@ -1,0 +1,182 @@
+# HCNN × Solar-PV Research Program — Execution Roadmap
+
+How the group actually delivers the topics in [`msc_topics_solar_pv.md`](msc_topics_solar_pv.md):
+shared infrastructure, data strategy, a repeatable per-topic recipe, a 12-month MSc
+timeline, governance, and risks. The guiding idea is that **students should not each
+rebuild the plumbing** — we build a shared foundation once (on the clean, CI-guarded
+`hcnn` package) so every thesis is a focused scientific contribution on top of it.
+
+---
+
+## 1. Guiding principles
+
+1. **Simulation-first, real-data-second.** Every topic is prototyped on a
+   high-fidelity physics simulation (PVLib / Simulink single-diode + thermal +
+   soiling + array models) that emits **both the observables and the ground-truth
+   latent states**. This is uniquely valuable for HCNN: we can *validate the
+   inferred hidden state* (soiling, cell temperature, diode parameters, shading map)
+   against simulation truth before touching noisy field data — and it de-risks the
+   biggest threat (scarce real labels).
+2. **Physics as a prior, not a postprocessor.** The single-diode equation, thermal
+   energy balance, and monotone degradation enter as differentiable
+   constraints/regularizers on the HCNN state, not as separate models.
+3. **One shared evaluation standard.** Valid-prediction-time, CRPS/coverage, and the
+   *domain engineering baselines* (P&O, INC, PSO, HSU/Kimber, Faiman) are implemented
+   once, so "HCNN outperforms" is comparable and defensible across theses.
+4. **Leakage-safe by construction.** Everyone uses the repo's data contract
+   (split-then-fit normalization, burn-in, val ≠ test) enforced by `CONTRIBUTING.md`
+   and CI.
+5. **Everything through the PR + CI process.** Shared-foundation code is reviewed and
+   test-gated like any contribution.
+
+---
+
+## 2. Phase 0 — The shared foundation (build once, reuse everywhere)
+
+This is the critical enabler and should exist before students start topic work. It
+extends `hcnn` the same way `chaotic_data/` supports the chaotic experiments.
+
+| Module (proposed) | Purpose | Analogue in repo |
+|-------------------|---------|------------------|
+| `hcnn/systems/pv/single_diode.py` | Differentiable single-diode I–V, MPP solver | `chaotic_data/systems.py` |
+| `hcnn/systems/pv/thermal.py` | Lumped thermal energy-balance (cell temp dynamics) | — |
+| `hcnn/systems/pv/soiling.py` | Soiling accumulation / rain wash-off (hysteretic) | — |
+| `hcnn/systems/pv/array.py` | Multi-module array, bypass diodes, partial-shading P–V, spatial topology | — |
+| `hcnn/systems/pv/faults.py` | Fault injectors (arc, hot-spot, diode, disconnect, degradation) | — |
+| `hcnn/systems/pv/generators.py` | Emit trajectories **with latent ground truth** + burn-in, leakage-safe loaders | `LorenzSolver` + `SlidingWindowDataset` |
+| `hcnn/physics/priors.py` | Diode residual, thermal balance, monotonicity as loss terms | `model_utils/custom_losses` |
+| `hcnn/evaluation/metrics.py` | Valid-prediction-time, CRPS, coverage, tracking efficiency | — |
+| `hcnn/evaluation/baselines.py` | Reference P&O/INC/PSO/HSU/Kimber/Faiman + adapters to `hcnn.baselines` LSTM/RNN | `hcnn.baselines` |
+| `benchmarks/` | Standard task suite + a small CI smoke benchmark | `tests/` |
+
+**Ownership:** advisor + one "infrastructure lead" student build Phase 0; it is not a
+thesis by itself but every thesis depends on it. Target: **~6–8 weeks**.
+
+---
+
+## 3. Data strategy
+
+The **simulation source is the workhorse**; the **real source is for validation and
+the novelty claim**. The colleague's African field data is the differentiator for the
+efficiency topics and must be secured early.
+
+| Topic(s) | Simulation (primary) | Real validation | What to obtain from colleague |
+|----------|----------------------|-----------------|-------------------------------|
+| 1.1, 1.2 MPPT | PVLib / Simulink single-diode under measured G/T | NREL PVDAQ, Sandia I–V | high-rate inverter I/V logs |
+| 2.1, 2.3 Faults | Simulink fault injection | **GPVS-Faults** (labeled), **DKASC** healthy | any logged fault events |
+| 2.2 Degradation/RUL | synthetic multi-year degradation | NREL / DKASC multi-year | multi-year performance history |
+| 3.1 Soiling | `soiling.py` accumulation model | **DKASC Alice Springs** (arid analogue), NREL soiling | cleaning logs + African power/weather |
+| 3.2 Climate transfer | multi-site simulated micro-climates | multi-site African data | **≥2–3 sites, different zones** |
+| 3.3 Thermal | `thermal.py` energy balance | back-of-module T datasets | back-of-module temperature |
+| 4.1–4.3 Shading | `array.py` moving-shadow scenarios | module-level array datasets (scarce → sim-led) | module/string-level telemetry |
+| A, B Microgrid | aggregated simulated fleet | **Open Power System Data**, NREL fleet + local demand | fleet + demand co-located data |
+
+**Weather everywhere:** NASA POWER and the Global Solar Atlas provide irradiance /
+temperature / humidity for any African coordinate — the exogenous driver for all
+topics.
+
+**Data governance:** agree a data-sharing arrangement with the colleague in month 0
+(licensing, anonymization, storage); standardize every source into the repo's
+`SlidingWindowDataset` contract; keep raw data out of git (already gitignored),
+version only the loaders and a small sample.
+
+---
+
+## 4. Per-topic execution recipe (every student follows this)
+
+A repeatable 8-step pipeline on the shared foundation. Each step maps to a concrete
+interface we already have.
+
+1. **Name the hidden-state prior** — the unobserved dynamical variable (soiling,
+   diode params, cell temp, degradation, shading regime). *This is the thesis.*
+2. **Simulate** with `hcnn.systems.pv` → observables **+ latent ground truth**.
+3. **Reproduce baselines** — engineering (`hcnn.evaluation.baselines`) + ML
+   (`hcnn.baselines` LSTM/RNN). Establishes the bar.
+4. **Build the HCNN variant** — subclass `BaseHCNNCell` if the recurrence changes;
+   pick Vanilla/PTF/LForm/LSpa; add the physics prior from `hcnn.physics`.
+5. **Train leakage-safe** — `HCNNTrainer`/`BaseTrainer`, split-then-fit, burn-in.
+6. **Validate hidden-state recovery** — compare the inferred latent state to the
+   simulation ground truth (the step black-box ML *cannot* do).
+7. **Transfer to real data** — fine-tune / adapt; report the sim-to-real gap.
+8. **Ablate & compare** — vs baselines with the shared metrics; write.
+
+---
+
+## 5. Master timeline (per MSc, ~12 months)
+
+| Months | Phase | Student deliverable | Gate |
+|--------|-------|---------------------|------|
+| 0–1 | Onboarding | Run `hcnn`, reproduce a Lorenz forecast, HCNN + domain lit review | Can run + explain the observer view |
+| 1–3 | Foundation + data | Contribute to / consume Phase-0 PV modules; simulate topic data | Simulated dataset with latent truth |
+| 2–4 | Baselines | Engineering + ML baselines reproduced on the task | Baseline numbers locked |
+| 4–8 | HCNN method | Hidden-state prior + physics constraint + variant; hidden-state recovery on sim | HCNN beats ML baseline on sim |
+| 6–9 | Sim→real | Transfer to real data; quantify gap | Result holds on real data |
+| 9–11 | Experiments | Ablations, comparison vs engineering baseline, UQ | HCNN ≥ engineering baseline |
+| 11–12 | Writing | Thesis + conference/journal draft | Submitted |
+
+Phase 0 runs in parallel with the first cohort's onboarding; later cohorts inherit it.
+
+---
+
+## 6. Team, governance, cadence
+
+- **Advisor (you):** methodology, the observer/Kalman-gain framing, cross-topic
+  consistency, review PRs.
+- **PV colleague:** domain correctness (physics, baselines), field data, validation.
+- **Infrastructure-lead student:** owns Phase 0; second-authors on others' methods.
+- **Topic students:** one topic each, following the §4 recipe.
+- **Cadence:** weekly student 1:1s, **monthly cohort review** (everyone presents
+  against the shared metrics), shared code via PR + green CI only.
+
+---
+
+## 7. Infrastructure & tooling
+
+- **Repo:** `hcnn` (single source of truth), `hcnn.baselines` for comparison,
+  new `hcnn.systems.pv` / `hcnn.physics` / `hcnn.evaluation` for Phase 0.
+- **CI:** extend the existing GitHub Actions to also run the `benchmarks/` smoke
+  suite so a regression in a shared PV model is caught immediately.
+- **Compute:** these models are small — the demo trains on CPU in ~1 min; MPS/CUDA is
+  a nice-to-have, not a blocker. A shared results/leaderboard table (CSV in repo) per
+  benchmark keeps comparisons honest.
+- **Reproducibility:** seeds fixed (`torch.manual_seed`), env pinned via
+  `requirements-dev.txt`, data loaders versioned, raw data out of git.
+
+---
+
+## 8. Risk register
+
+| # | Risk | Likelihood | Mitigation |
+|---|------|-----------|------------|
+| R1 | African field data scarce / low quality | **High** | Simulation-first; DKASC (arid analogue) + NASA POWER; secure colleague data in month 0 |
+| R2 | Sim-to-real gap | Medium | Validate on real early (step 7); Topic 3.2 (climate adaptation) doubles as the mitigation study |
+| R3 | MSc scope creep | Medium | The §4 recipe + simulation-first bound the work; one hidden-state prior per thesis |
+| R4 | Reproducibility / leakage | Low (now) | Enforced by `CONTRIBUTING.md` invariants + CI |
+| R5 | Shared-foundation delays block students | Medium | Advisor + lead own Phase 0; ship `single_diode.py` + metrics harness first (unblocks 1.x, 4.x) |
+| R6 | Weak baseline → indefensible claim | Medium | `hcnn.evaluation.baselines` mandates the domain baseline, not just LSTM |
+
+---
+
+## 9. Definition of done (per phase)
+
+- **Phase 0:** PV generators emit latent truth; physics priors + metrics + baselines
+  importable; smoke benchmark green in CI.
+- **Method:** HCNN recovers the latent state on simulation (quantified) and beats the
+  ML baseline.
+- **Thesis:** HCNN ≥ the *engineering* baseline on real data, with calibrated
+  uncertainty, on the shared metrics; reproducible from the repo.
+
+---
+
+## 10. Immediate next actions (first 2–4 weeks)
+
+1. **Confirm the cohort:** which of the 12 topics, which students, who is the
+   infrastructure lead.
+2. **Secure data:** data-sharing agreement + sample from the colleague; download
+   DKASC, GPVS-Faults, NASA POWER for the target sites.
+3. **Ship the first Phase-0 slice:** `hcnn.systems.pv.single_diode` (+ MPP solver) and
+   `hcnn.evaluation.metrics` — this alone unblocks Topics 1.1, 1.2, 4.1.
+4. **Stand up the benchmark:** one task (e.g. MPP tracking on simulated cloudy days)
+   with P&O + LSTM baselines, as the template all topics copy.
+5. **Pick the two lead theses** (2.1 residual faults; 3.1 latent soiling) to start —
+   highest distinctiveness, clearest hidden-state story.


### PR DESCRIPTION
## Summary

Adds two planning documents for the HCNN × Solar-PV MSc program (no code changes):

- `docs/msc_topics_solar_pv.md` — 12 candidate MSc topics (4 colleague suggestions × 2–3 + 2 microgrid bonus), each framing the PV system as a partially-observed nonlinear dynamical system so HCNN's hidden-state inference and innovation-residual are *required*. Includes a topic × variant × hidden-state-prior × baseline × data × metric selection matrix.
- `docs/research_program_roadmap.md` — the execution plan: simulation-first strategy, a shared Phase-0 foundation to build on `hcnn` (PV generators with latent ground truth, differentiable physics priors, evaluation harness + engineering baselines), a per-topic 8-step recipe on the `BaseHCNNCell`/`BaseTrainer` interfaces, a 12-month timeline with gates, data strategy per topic, governance, risk register, and immediate next actions.

## Type of change
- [x] `docs` — documentation only

## How was this tested?
Docs only — no code paths affected; existing CI (tests/) remains green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)